### PR TITLE
Include step adding query scheme to Info.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 - Descarga el SDK como binario en un archivo `.framework` desde desde [la página de releases](https://github.com/TransbankDevelopers/transbank-sdk-ios-onepay/releases). Para comenzar el desarrollo puedes usar la versión para ambiente de Test (y luego deberás compilar contra la versión de Producción para tu app productiva)
 - Descomprime el archivo `.zip` para quedar con el directorio `.framework`.
 - Arrastra `OnePaySDK` a la sección "Embedded Binaries" en la configuración "General" de tu proyecto. Marca la casilla "Copy items if needed" y haz click en "Finish"
+- En el archivo Info.plist, agrega lo siguiente para que tu aplicación pueda consultar si existe Onepay:
+
+```
+<key>LSApplicationQueriesSchemes</key>
+  <array>
+    <string>onepay</string>        
+  </array>
+```
 
 ## Modo de uso  
 


### PR DESCRIPTION
The app who integrates Onepay must add an specific query scheme configuration in Info.plist, to be able to ask if Onepay app is installed.