### PR TITLE
Add QR Drawing to the SDK

### DIFF
--- a/OnePaySDK.xcodeproj/project.pbxproj
+++ b/OnePaySDK.xcodeproj/project.pbxproj
@@ -7,12 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6FC1228721F90C1F00501A54 /* QROnepayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FC1228521F90C1F00501A54 /* QROnepayView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6FC1228821F90C1F00501A54 /* QROnepayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FC1228621F90C1F00501A54 /* QROnepayView.m */; };
 		BC347B342078080700C2BC50 /* OnePaySDK.h in Headers */ = {isa = PBXBuildFile; fileRef = BC347B322078080700C2BC50 /* OnePaySDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BC347B3C2078081800C2BC50 /* OnePay.m in Sources */ = {isa = PBXBuildFile; fileRef = BC347B3A2078081800C2BC50 /* OnePay.m */; };
 		BC347B3D2078081800C2BC50 /* OnePay.h in Headers */ = {isa = PBXBuildFile; fileRef = BC347B3B2078081800C2BC50 /* OnePay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6FC1228521F90C1F00501A54 /* QROnepayView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QROnepayView.h; sourceTree = "<group>"; };
+		6FC1228621F90C1F00501A54 /* QROnepayView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QROnepayView.m; sourceTree = "<group>"; };
 		BC347B2F2078080700C2BC50 /* OnePaySDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OnePaySDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC347B322078080700C2BC50 /* OnePaySDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnePaySDK.h; sourceTree = "<group>"; };
 		BC347B332078080700C2BC50 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -54,6 +58,8 @@
 				BC347B3A2078081800C2BC50 /* OnePay.m */,
 				BC347B322078080700C2BC50 /* OnePaySDK.h */,
 				BC347B332078080700C2BC50 /* Info.plist */,
+				6FC1228521F90C1F00501A54 /* QROnepayView.h */,
+				6FC1228621F90C1F00501A54 /* QROnepayView.m */,
 			);
 			path = OnePaySDK;
 			sourceTree = "<group>";
@@ -67,6 +73,7 @@
 			files = (
 				BC347B3D2078081800C2BC50 /* OnePay.h in Headers */,
 				BC347B342078080700C2BC50 /* OnePaySDK.h in Headers */,
+				6FC1228721F90C1F00501A54 /* QROnepayView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,6 +146,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BC347B3C2078081800C2BC50 /* OnePay.m in Sources */,
+				6FC1228821F90C1F00501A54 /* QROnepayView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OnePaySDK/OnePaySDK.h
+++ b/OnePaySDK/OnePaySDK.h
@@ -17,3 +17,4 @@ FOUNDATION_EXPORT const unsigned char OnePaySDKVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <OnePaySDK/PublicHeader.h>
 
 #import <OnePaySDK/OnePay.h>
+#import <OnePaySDK/QROnepayView.h>

--- a/OnePaySDK/QROnepayView.h
+++ b/OnePaySDK/QROnepayView.h
@@ -1,0 +1,18 @@
+//
+//  QROnepayView.h
+//
+//  Created by Rodrigo Ayala on 1/23/19.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface QROnepayView : UIImageView
+
+- (instancetype)init;
+- (instancetype)initWithOtt:(NSString * _Nonnull)ott;
+- (void)setOtt:(NSString * _Nonnull)ott;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OnePaySDK/QROnepayView.m
+++ b/OnePaySDK/QROnepayView.m
@@ -1,0 +1,79 @@
+//
+//  QROnepayView.m
+//
+//  Created by Rodrigo Ayala on 1/23/19.
+//
+
+#import "QROnepayView.h"
+
+@implementation QROnepayView
+NSData *_data;
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _data = nil;
+    }
+    return self;
+}
+
+- (instancetype)initWithOtt:(NSString *)ott {
+    if ((self = [super init])) {
+        _data = [self generateQRDataFrom:ott];
+    }
+    self.image = [self getQRImage];
+    return self;
+}
+
+- (NSData*) generateQRDataFrom:(NSString*)ott {
+    return [[@"onepay=ott:" stringByAppendingString:ott] dataUsingEncoding:NSISOLatin1StringEncoding];
+}
+
+- (void) setOtt:(NSString *)ott {
+    _data = [self generateQRDataFrom:ott];
+    self.image = [self getQRImage];
+}
+
+- (UIImage *)getQRImage {
+    UIImage *r = nil;
+    @try {
+        CIImage *src = [self getCIImage];
+        if (!src || src == nil) { return nil; }
+        
+        CGRect imageSize = CGRectIntegral(src.extent);
+        CGSize outputSize = CGSizeMake(200.0f, 200.0f);
+        CIImage *imageByTransform = [src imageByApplyingTransform:CGAffineTransformMakeScale(outputSize.width/CGRectGetWidth(imageSize), outputSize.height/CGRectGetHeight(imageSize))];
+        
+        r = [UIImage imageWithCIImage:imageByTransform];
+    } @catch (NSException *exception) {
+        NSLog(@"Error: %@", exception.reason);
+    }
+    return r;
+}
+
+- (CIImage *)getCIImage {
+    CIImage *r = nil;
+    @try {
+        if (!_data || _data == nil || _data.length <= 0) { return nil; }
+        
+        CIFilter *qrCodeFilter = [CIFilter filterWithName:@"CIQRCodeGenerator"];
+        if (qrCodeFilter == nil) { return nil; }
+        [qrCodeFilter setDefaults];
+        [qrCodeFilter setValue:_data forKey:@"inputMessage"];
+        [qrCodeFilter setValue:@"L" forKey:@"inputCorrectionLevel"];
+        
+        CIFilter *colorFilter = [CIFilter filterWithName:@"CIFalseColor"];
+        if (colorFilter == nil) { return nil; }
+        [colorFilter setDefaults];
+        [colorFilter setValue:qrCodeFilter.outputImage forKey:@"inputImage"];
+        [colorFilter setValue:[CIColor colorWithRed:0.0f green:0.0f blue:0.0f] forKey:@"inputColor0"];
+        [colorFilter setValue:[CIColor colorWithRed:1.0f green:1.0f blue:1.0f] forKey:@"inputColor1"];
+        
+        r = colorFilter.outputImage;
+        
+    } @catch (NSException *exception) {
+        NSLog(@"Error: %@", exception.reason);
+    }
+    return r;
+}
+
+@end


### PR DESCRIPTION
When implementing [cortafilas](https://www.transbankdevelopers.cl/producto/onepay#onepay-como-cortafila) mode in an iOS App, it's necessary to draw an specific QR based on the OTT retrieved from the Transaction.create backend method.

This PR adds QR drawing to the iOS SDK.